### PR TITLE
fix: 修复开启wheel悬停滚动，无法滚动问题

### DIFF
--- a/package/Vue3SeamlessScroll.tsx
+++ b/package/Vue3SeamlessScroll.tsx
@@ -363,7 +363,7 @@ const Vue3SeamlessScroll = defineComponent({
       () => props.hover && props.modelValue && isScroll.value
     );
 
-    const throttleFunc = throttle(30, undefined, (e: WheelEvent) => {
+    const throttleFunc = throttle(30, (e: WheelEvent) => {
       cancle();
       const singleHeight = !!realSingleStopHeight.value
         ? realSingleStopHeight.value


### PR DESCRIPTION
我发现当开启wheel的时候，列表无法进行滚动。我删除throttle的第二个参数undefined解决了这个问题